### PR TITLE
Legg til Dependabot for automatisk avhengighetsoppdatering [#10]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    labels:
+      - 'dependencies'
+    groups:
+      per-major-dependency:
+        patterns:
+          - '*'
+        update-types:
+          - 'major'
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies-github-actions'


### PR DESCRIPTION
**🛠️ Hva er gjort?**
Denne PR-en introduserer Dependabot i prosjektet, slik at avhengigheter i package.json og GitHub Actions oppdateres automatisk.

**🔄 Oppsett av Dependabot-konfigurasjonen:**
NPM-avhengigheter:
Major updates (major versjonsendringer) grupperes i én PR.
Minor og patch updates (minor + patch versjonsendringer) grupperes sammen i en egen PR.
GitHub Actions:
Oppdateres ukentlig via Dependabot.

**🎯 Hvorfor denne endringen?**
Automatiserer oppdateringer av avhengigheter for å sikre sikkerhet og stabilitet.
Reduserer teknisk gjeld ved å holde bibliotekene oppdatert over tid.
Grupperer oppdateringer smart, slik at vi får færre, men mer oversiktlige PR-er.
